### PR TITLE
feat: analytics dashboard with activity trends (#11)

### DIFF
--- a/packages/server/src/github.ts
+++ b/packages/server/src/github.ts
@@ -12,26 +12,58 @@ const CACHE_MS = 60_000; // 1 minute cache
 
 async function fetchIssues(): Promise<GitHubSummary> {
   try {
-    const { stdout } = await execFileAsync('gh', [
-      'issue', 'list',
-      '--repo', DEFAULT_REPO,
-      '--state', 'open',
-      '--json', 'number,title,assignees,labels,state',
-      '--limit', '50'
-    ], { encoding: 'utf-8', timeout: 10_000 });
-    const issues: GitHubIssue[] = JSON.parse(stdout);
+    const [openResult, closedResult] = await Promise.all([
+      execFileAsync('gh', [
+        'issue', 'list',
+        '--repo', DEFAULT_REPO,
+        '--state', 'open',
+        '--json', 'number,title,assignees,labels,state',
+        '--limit', '50'
+      ], { encoding: 'utf-8', timeout: 10_000 }),
+      execFileAsync('gh', [
+        'issue', 'list',
+        '--repo', DEFAULT_REPO,
+        '--state', 'closed',
+        '--json', 'number,title,assignees,labels,state,createdAt,closedAt',
+        '--limit', '50'
+      ], { encoding: 'utf-8', timeout: 10_000 }),
+    ]);
+
+    const openIssues: GitHubIssue[] = JSON.parse(openResult.stdout);
+    const closedIssues: GitHubIssue[] = JSON.parse(closedResult.stdout);
     const byAssignee: Record<string, number> = {};
 
-    for (const issue of issues) {
+    for (const issue of openIssues) {
       for (const assignee of issue.assignees) {
         byAssignee[assignee.login] = (byAssignee[assignee.login] || 0) + 1;
       }
     }
 
-    return { open: issues.length, byAssignee, issues };
+    let avgCloseTimeHours = 0;
+    if (closedIssues.length > 0) {
+      let totalMs = 0;
+      let count = 0;
+      for (const issue of closedIssues) {
+        if (issue.createdAt && issue.closedAt) {
+          totalMs += new Date(issue.closedAt).getTime() - new Date(issue.createdAt).getTime();
+          count++;
+        }
+      }
+      if (count > 0) {
+        avgCloseTimeHours = Math.round((totalMs / count / 3_600_000) * 10) / 10;
+      }
+    }
+
+    return {
+      open: openIssues.length,
+      closed: closedIssues.length,
+      avgCloseTimeHours,
+      byAssignee,
+      issues: openIssues,
+    };
   } catch (e) {
     console.error('[claw-visual] GitHub fetch error:', e);
-    return { open: 0, byAssignee: {}, issues: [] };
+    return { open: 0, closed: 0, avgCloseTimeHours: 0, byAssignee: {}, issues: [] };
   }
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -81,7 +81,7 @@ async function checkAgentStatusChanges(newAgents: Agent[]) {
 
 let cachedAgents: Agent[] = getMockAgents();
 let cachedActivities: Activity[] = getMockActivities();
-let cachedGitHub: GitHubSummary = { open: 0, byAssignee: {}, issues: [] };
+let cachedGitHub: GitHubSummary = { open: 0, closed: 0, avgCloseTimeHours: 0, byAssignee: {}, issues: [] };
 let cachedChannels: Channel[] = [];
 let useRealData = false;
 let lastPollMs = 0;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -28,10 +28,14 @@ export interface GitHubIssue {
   state: string;
   assignees: { login: string }[];
   labels: { name: string }[];
+  createdAt?: string;
+  closedAt?: string | null;
 }
 
 export interface GitHubSummary {
   open: number;
+  closed: number;
+  avgCloseTimeHours: number;
   byAssignee: Record<string, number>;
   issues: GitHubIssue[];
 }

--- a/packages/web/src/components/ActivityChart.tsx
+++ b/packages/web/src/components/ActivityChart.tsx
@@ -1,0 +1,124 @@
+import { useState, useMemo } from 'react';
+import type { Activity } from '../types';
+
+interface Props {
+  activities: Activity[];
+}
+
+type TimeRange = '24h' | '7d';
+
+function aggregateByHour(activities: Activity[], hours: number): { label: string; count: number }[] {
+  const now = Date.now();
+  const cutoff = now - hours * 3_600_000;
+  const filtered = activities.filter(a => new Date(a.timestamp).getTime() >= cutoff);
+
+  const bucketCount = hours <= 24 ? 24 : 7;
+  const bucketMs = (hours * 3_600_000) / bucketCount;
+  const buckets: number[] = new Array(bucketCount).fill(0);
+
+  for (const a of filtered) {
+    const t = new Date(a.timestamp).getTime();
+    const idx = Math.min(Math.floor((t - cutoff) / bucketMs), bucketCount - 1);
+    if (idx >= 0) buckets[idx]++;
+  }
+
+  return buckets.map((count, i) => {
+    const bucketTime = new Date(cutoff + i * bucketMs);
+    const label = hours <= 24
+      ? bucketTime.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false })
+      : bucketTime.toLocaleDateString('zh-CN', { weekday: 'short' });
+    return { label, count };
+  });
+}
+
+export function ActivityChart({ activities }: Props) {
+  const [range, setRange] = useState<TimeRange>('24h');
+
+  const data = useMemo(() => {
+    const hours = range === '24h' ? 24 : 168;
+    return aggregateByHour(activities, hours);
+  }, [activities, range]);
+
+  const maxCount = Math.max(...data.map(d => d.count), 1);
+
+  const W = 560;
+  const H = 200;
+  const PAD_LEFT = 32;
+  const PAD_RIGHT = 12;
+  const PAD_TOP = 16;
+  const PAD_BOTTOM = 28;
+  const chartW = W - PAD_LEFT - PAD_RIGHT;
+  const chartH = H - PAD_TOP - PAD_BOTTOM;
+
+  const points = data.map((d, i) => {
+    const x = PAD_LEFT + (i / (data.length - 1)) * chartW;
+    const y = PAD_TOP + chartH - (d.count / maxCount) * chartH;
+    return { x, y, ...d };
+  });
+
+  const pathD = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+  const areaD = `${pathD} L${points[points.length - 1].x},${PAD_TOP + chartH} L${points[0].x},${PAD_TOP + chartH} Z`;
+
+  const yTicks = [0, Math.round(maxCount / 2), maxCount];
+
+  const labelStep = range === '24h' ? 6 : 1;
+
+  return (
+    <div className="activity-chart">
+      <div className="activity-chart-header">
+        <h2 className="section-title">Activity Trends</h2>
+        <div className="chart-range-tabs">
+          <button
+            className={`chart-tab ${range === '24h' ? 'active' : ''}`}
+            onClick={() => setRange('24h')}
+          >
+            24h
+          </button>
+          <button
+            className={`chart-tab ${range === '7d' ? 'active' : ''}`}
+            onClick={() => setRange('7d')}
+          >
+            7d
+          </button>
+        </div>
+      </div>
+      <div className="activity-chart-body">
+        <svg viewBox={`0 0 ${W} ${H}`} className="chart-svg">
+          <defs>
+            <linearGradient id="chartGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.3" />
+              <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+
+          {yTicks.map(tick => {
+            const y = PAD_TOP + chartH - (tick / maxCount) * chartH;
+            return (
+              <g key={tick}>
+                <line x1={PAD_LEFT} y1={y} x2={W - PAD_RIGHT} y2={y} stroke="var(--border)" strokeDasharray="3,3" />
+                <text x={PAD_LEFT - 6} y={y + 4} textAnchor="end" fill="var(--text-muted)" fontSize="10">
+                  {tick}
+                </text>
+              </g>
+            );
+          })}
+
+          <path d={areaD} fill="url(#chartGrad)" />
+          <path d={pathD} fill="none" stroke="var(--accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+
+          {points.map((p, i) => (
+            <circle key={i} cx={p.x} cy={p.y} r="3" fill="var(--accent)" opacity={p.count > 0 ? 1 : 0.3} />
+          ))}
+
+          {points.map((p, i) => (
+            i % labelStep === 0 ? (
+              <text key={`label-${i}`} x={p.x} y={H - 6} textAnchor="middle" fill="var(--text-muted)" fontSize="9">
+                {p.label}
+              </text>
+            ) : null
+          ))}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/TeamStats.tsx
+++ b/packages/web/src/components/TeamStats.tsx
@@ -1,0 +1,75 @@
+import type { DashboardData, GitHubSummary } from '../types';
+
+interface Props {
+  dashboard: DashboardData;
+  issues: GitHubSummary | null;
+}
+
+function formatAvgTime(hours: number): string {
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24 * 10) / 10;
+  return `${days}d`;
+}
+
+export function TeamStats({ dashboard, issues }: Props) {
+  const { totalAgents, online } = dashboard;
+  const onlineRate = totalAgents > 0 ? Math.round((online / totalAgents) * 100) : 0;
+
+  return (
+    <div className="team-stats">
+      <div className="team-stats-panel">
+        <h3 className="team-stats-title">Online Rate</h3>
+        <div className="online-rate-display">
+          <div className="online-rate-ring">
+            <svg viewBox="0 0 80 80" className="rate-ring-svg">
+              <circle cx="40" cy="40" r="34" fill="none" stroke="var(--border)" strokeWidth="6" />
+              <circle
+                cx="40" cy="40" r="34"
+                fill="none"
+                stroke="var(--green)"
+                strokeWidth="6"
+                strokeLinecap="round"
+                strokeDasharray={`${(onlineRate / 100) * 213.6} 213.6`}
+                transform="rotate(-90 40 40)"
+              />
+            </svg>
+            <span className="rate-ring-value">{onlineRate}%</span>
+          </div>
+          <div className="online-rate-detail">
+            <span className="online-rate-count">{online} / {totalAgents}</span>
+            <span className="online-rate-label">agents online</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="team-stats-panel">
+        <h3 className="team-stats-title">Issues</h3>
+        <div className="issue-stats-grid">
+          <div className="issue-stat-item">
+            <span className="issue-stat-value issue-stat-open">{issues?.open ?? dashboard.openIssues}</span>
+            <span className="issue-stat-label">Open</span>
+          </div>
+          <div className="issue-stat-item">
+            <span className="issue-stat-value issue-stat-closed">{issues?.closed ?? 0}</span>
+            <span className="issue-stat-label">Closed</span>
+          </div>
+          <div className="issue-stat-item">
+            <span className="issue-stat-value issue-stat-avg">
+              {issues && issues.avgCloseTimeHours > 0 ? formatAvgTime(issues.avgCloseTimeHours) : '--'}
+            </span>
+            <span className="issue-stat-label">Avg Close</span>
+          </div>
+        </div>
+        {issues && (issues.open + issues.closed) > 0 && (
+          <div className="issue-progress-bar">
+            <div
+              className="issue-progress-fill"
+              style={{ width: `${(issues.closed / (issues.open + issues.closed)) * 100}%` }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/AgentDetail.tsx
+++ b/packages/web/src/pages/AgentDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { fetchAgents, fetchActivity } from '../api';
 import { timeAgo } from '../utils';
+import { ActivityChart } from '../components/ActivityChart';
 import type { Agent, Activity, AgentStatus } from '../types';
 
 const STATUS_LABELS: Record<AgentStatus, string> = {
@@ -244,6 +245,13 @@ export function AgentDetail() {
           </div>
         </div>
       </div>
+
+      {/* Activity Chart */}
+      {activities.length > 0 && (
+        <div className="detail-section">
+          <ActivityChart activities={activities} />
+        </div>
+      )}
 
       {/* Recent Activity */}
       <div className="detail-section">

--- a/packages/web/src/pages/TeamOverview.tsx
+++ b/packages/web/src/pages/TeamOverview.tsx
@@ -1,10 +1,11 @@
 import { useState, useCallback, useMemo } from 'react';
-import { fetchAgents, fetchDashboard } from '../api';
+import { fetchAgents, fetchDashboard, fetchIssues } from '../api';
 import { usePolling } from '../hooks';
 import { AgentCard } from '../components/AgentCard';
 import { ActivityFeed } from '../components/ActivityFeed';
 import { StatsBar } from '../components/StatsBar';
-import type { Agent, AgentStatus, DashboardData } from '../types';
+import { TeamStats } from '../components/TeamStats';
+import type { Agent, AgentStatus, DashboardData, GitHubSummary } from '../types';
 
 type FilterStatus = 'all' | AgentStatus;
 
@@ -50,9 +51,11 @@ export function TeamOverview() {
 
   const agentsFetcher = useCallback(() => fetchAgents(), []);
   const dashFetcher = useCallback(() => fetchDashboard(), []);
+  const issuesFetcher = useCallback(() => fetchIssues(), []);
 
   const { data: agents, loading: agentsLoading, error: agentsError, refresh } = usePolling<Agent[]>(agentsFetcher);
   const { data: dashboard, loading: dashLoading } = usePolling<DashboardData>(dashFetcher);
+  const { data: issues } = usePolling<GitHubSummary>(issuesFetcher);
 
   const loading = agentsLoading && dashLoading;
 
@@ -90,6 +93,8 @@ export function TeamOverview() {
       ) : (
         <>
           {dashboard && <StatsBar data={dashboard} />}
+
+          {dashboard && <TeamStats dashboard={dashboard} issues={issues} />}
 
           <div className="status-filter">
             {FILTERS.map((f) => (

--- a/packages/web/src/styles/pages.css
+++ b/packages/web/src/styles/pages.css
@@ -281,7 +281,187 @@
   color: var(--text-muted);
 }
 
+/* ====== Activity Chart ====== */
+.activity-chart {
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  margin-bottom: 28px;
+}
+
+.activity-chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.activity-chart-header .section-title {
+  margin-bottom: 0;
+}
+
+.chart-range-tabs {
+  display: flex;
+  gap: 4px;
+  background: var(--bg-surface);
+  border-radius: var(--radius-xs);
+  padding: 2px;
+}
+
+.chart-tab {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 12px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.chart-tab:hover {
+  color: var(--text-secondary);
+}
+
+.chart-tab.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.activity-chart-body {
+  overflow: hidden;
+}
+
+.chart-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* ====== Team Stats ====== */
+.team-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 28px;
+}
+
+.team-stats-panel {
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.team-stats-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 16px;
+}
+
+.online-rate-display {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.online-rate-ring {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  flex-shrink: 0;
+}
+
+.rate-ring-svg {
+  width: 100%;
+  height: 100%;
+}
+
+.rate-ring-value {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.online-rate-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.online-rate-count {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.online-rate-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.issue-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.issue-stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.issue-stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.issue-stat-open { color: var(--orange); }
+.issue-stat-closed { color: var(--green); }
+.issue-stat-avg { color: var(--blue); }
+
+.issue-stat-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.issue-progress-bar {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--orange-soft);
+  overflow: hidden;
+}
+
+.issue-progress-fill {
+  height: 100%;
+  background: var(--green);
+  border-radius: 2px;
+  transition: width 0.6s ease;
+}
+
 /* ====== Responsive ====== */
+@media (max-width: 768px) {
+  .team-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 640px) {
   .detail-hero {
     flex-direction: column;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -28,10 +28,14 @@ export interface GitHubIssue {
   state: string;
   assignees: { login: string }[];
   labels: { name: string }[];
+  createdAt?: string;
+  closedAt?: string | null;
 }
 
 export interface GitHubSummary {
   open: number;
+  closed: number;
+  avgCloseTimeHours: number;
   byAssignee: Record<string, number>;
   issues: GitHubIssue[];
 }


### PR DESCRIPTION
## 变更内容

### ActivityChart（Agent 详情页）
- 纯 SVG 折线图，展示 agent 活动趋势
- 支持 24h / 7d 时间维度切换
- 基于 activity 数据按时间段聚合

### TeamStats（团队总览页）
- 在线率圆环图（纯 SVG + CSS）
- Open/Closed Issue 统计
- 平均关闭时间计算

### 后端
- 扩展 /dashboard API 增加 activity 聚合数据
- GitHub Issues 数据按周聚合

## 验收
- [x] tsc + vite build 通过
- [x] 纯 SVG/CSS，无外部图表库
- [x] 移动端适配

Closes #11