### PR TITLE
feat: settings page with theme toggle and config (#13)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { TeamOverview } from './pages/TeamOverview';
 import { ChannelView } from './pages/ChannelView';
 import { AgentDetail } from './pages/AgentDetail';
+import { SettingsPage } from './pages/SettingsPage';
 
 export function App() {
   return (
@@ -14,6 +15,7 @@ export function App() {
             <Route index element={<TeamOverview />} />
             <Route path="channels" element={<ChannelView />} />
             <Route path="agents/:id" element={<AgentDetail />} />
+            <Route path="settings" element={<SettingsPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -44,6 +44,9 @@ export function Layout() {
                 {onlineCount} online
               </span>
             )}
+            <NavLink to="/settings" className={({ isActive }) => isActive ? 'nav-link nav-settings active' : 'nav-link nav-settings'} title="Settings">
+              &#9881;
+            </NavLink>
           </div>
         </div>
       </nav>

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,11 @@ import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './styles/main.css';
 
+const savedTheme = localStorage.getItem('claw-theme');
+if (savedTheme === 'light') {
+  document.documentElement.setAttribute('data-theme', 'light');
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/packages/web/src/pages/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,148 @@
+import { useState, useEffect } from 'react';
+
+type Theme = 'dark' | 'light';
+
+interface WebhookConfig {
+  url: string;
+  offlineAlert: boolean;
+  recoveryNotify: boolean;
+}
+
+interface ThresholdConfig {
+  offlineThreshold: number;
+}
+
+function getTheme(): Theme {
+  return (localStorage.getItem('claw-theme') as Theme) || 'dark';
+}
+
+function applyTheme(theme: Theme) {
+  if (theme === 'light') {
+    document.documentElement.setAttribute('data-theme', 'light');
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+  }
+  localStorage.setItem('claw-theme', theme);
+}
+
+function getWebhookConfig(): WebhookConfig {
+  try {
+    const raw = localStorage.getItem('claw-webhook');
+    if (raw) return JSON.parse(raw);
+  } catch { /* ignore */ }
+  return { url: '', offlineAlert: false, recoveryNotify: false };
+}
+
+function getThresholdConfig(): ThresholdConfig {
+  try {
+    const raw = localStorage.getItem('claw-threshold');
+    if (raw) return JSON.parse(raw);
+  } catch { /* ignore */ }
+  return { offlineThreshold: 3 };
+}
+
+export function SettingsPage() {
+  const [theme, setTheme] = useState<Theme>(getTheme);
+  const [webhook, setWebhook] = useState<WebhookConfig>(getWebhookConfig);
+  const [threshold, setThreshold] = useState<ThresholdConfig>(getThresholdConfig);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const handleSave = () => {
+    localStorage.setItem('claw-webhook', JSON.stringify(webhook));
+    localStorage.setItem('claw-threshold', JSON.stringify(threshold));
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <div className="settings-page">
+      <h1 className="settings-title">Settings</h1>
+
+      {/* Theme */}
+      <section className="settings-section">
+        <h2 className="settings-section-title">Theme</h2>
+        <div className="theme-toggle-group">
+          <button
+            className={`theme-btn ${theme === 'dark' ? 'active' : ''}`}
+            onClick={() => setTheme('dark')}
+          >
+            <span className="theme-btn-icon">&#9790;</span>
+            Dark
+          </button>
+          <button
+            className={`theme-btn ${theme === 'light' ? 'active' : ''}`}
+            onClick={() => setTheme('light')}
+          >
+            <span className="theme-btn-icon">&#9788;</span>
+            Light
+          </button>
+        </div>
+      </section>
+
+      {/* Webhook */}
+      <section className="settings-section">
+        <h2 className="settings-section-title">Webhook</h2>
+        <div className="settings-field">
+          <label className="settings-label">Webhook URL</label>
+          <input
+            type="url"
+            className="settings-input"
+            placeholder="https://example.com/webhook"
+            value={webhook.url}
+            onChange={(e) => setWebhook({ ...webhook, url: e.target.value })}
+          />
+        </div>
+        <div className="settings-toggle-row">
+          <span className="settings-toggle-label">Offline Alert</span>
+          <button
+            className={`toggle-switch ${webhook.offlineAlert ? 'on' : ''}`}
+            onClick={() => setWebhook({ ...webhook, offlineAlert: !webhook.offlineAlert })}
+            role="switch"
+            aria-checked={webhook.offlineAlert}
+          >
+            <span className="toggle-knob" />
+          </button>
+        </div>
+        <div className="settings-toggle-row">
+          <span className="settings-toggle-label">Recovery Notification</span>
+          <button
+            className={`toggle-switch ${webhook.recoveryNotify ? 'on' : ''}`}
+            onClick={() => setWebhook({ ...webhook, recoveryNotify: !webhook.recoveryNotify })}
+            role="switch"
+            aria-checked={webhook.recoveryNotify}
+          >
+            <span className="toggle-knob" />
+          </button>
+        </div>
+      </section>
+
+      {/* Threshold */}
+      <section className="settings-section">
+        <h2 className="settings-section-title">Threshold</h2>
+        <div className="settings-field">
+          <label className="settings-label">Offline threshold (heartbeat failures)</label>
+          <input
+            type="number"
+            className="settings-input settings-input-sm"
+            min={1}
+            max={99}
+            value={threshold.offlineThreshold}
+            onChange={(e) => setThreshold({ ...threshold, offlineThreshold: Math.max(1, parseInt(e.target.value) || 1) })}
+          />
+        </div>
+      </section>
+
+      {/* Save */}
+      <div className="settings-actions">
+        <button className="settings-save-btn" onClick={handleSave}>
+          Save Configuration
+        </button>
+        {saved && <span className="settings-saved-msg">Saved!</span>}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/styles/base.css
+++ b/packages/web/src/styles/base.css
@@ -47,6 +47,42 @@
   --nav-height: 56px;
 }
 
+:root[data-theme='light'] {
+  --bg-primary: #f5f5f7;
+  --bg-secondary: #ffffff;
+  --bg-card: rgba(0,0,0,0.03);
+  --bg-card-solid: #ffffff;
+  --bg-hover: rgba(0,0,0,0.05);
+  --bg-surface: rgba(0,0,0,0.04);
+  --border: rgba(0,0,0,0.08);
+  --border-hover: rgba(0,0,0,0.15);
+  --text-primary: #1a1a2e;
+  --text-secondary: #555570;
+  --text-muted: #8e8ea0;
+  --accent: #4f46e5;
+  --accent-soft: rgba(79,70,229,0.1);
+  --green: #16a34a;
+  --green-soft: rgba(22,163,74,0.1);
+  --yellow: #ca8a04;
+  --yellow-soft: rgba(202,138,4,0.1);
+  --orange: #ea580c;
+  --orange-soft: rgba(234,88,12,0.1);
+  --red: #dc2626;
+  --red-soft: rgba(220,38,38,0.1);
+  --blue: #2563eb;
+  --blue-soft: rgba(37,99,235,0.1);
+  --purple: #9333ea;
+  --purple-soft: rgba(147,51,234,0.1);
+  --gray: #6b7280;
+  --gray-soft: rgba(107,114,128,0.1);
+  --glass-bg: rgba(255,255,255,0.7);
+  --glass-border: rgba(0,0,0,0.08);
+  --glass-blur: blur(12px);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
+  --shadow-lg: 0 8px 24px rgba(0,0,0,0.1);
+}
+
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: var(--bg-primary);

--- a/packages/web/src/styles/layout.css
+++ b/packages/web/src/styles/layout.css
@@ -167,3 +167,12 @@
   .app { padding: calc(var(--nav-height) + 16px) 12px 16px; }
   .nav-bar-inner { padding: 0 12px; }
 }
+
+:root[data-theme='light'] .nav-bar {
+  background: rgba(245,245,247,0.8);
+}
+
+:root[data-theme='light'] .skeleton {
+  background: linear-gradient(90deg, rgba(0,0,0,0.04) 25%, rgba(0,0,0,0.07) 50%, rgba(0,0,0,0.04) 75%);
+  background-size: 200% 100%;
+}

--- a/packages/web/src/styles/pages.css
+++ b/packages/web/src/styles/pages.css
@@ -281,6 +281,185 @@
   color: var(--text-muted);
 }
 
+/* ====== Settings Page ====== */
+.settings-page {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.settings-title {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 28px;
+}
+
+.settings-section {
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.settings-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 16px;
+}
+
+.theme-toggle-group {
+  display: flex;
+  gap: 8px;
+}
+
+.theme-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.theme-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.theme-btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.theme-btn-icon {
+  font-size: 16px;
+}
+
+.settings-field {
+  margin-bottom: 14px;
+}
+
+.settings-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.settings-input {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+.settings-input:focus {
+  border-color: var(--accent);
+}
+
+.settings-input-sm {
+  width: 80px;
+}
+
+.settings-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-top: 1px solid var(--border);
+}
+
+.settings-toggle-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.toggle-switch {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  border: none;
+  border-radius: 12px;
+  background: var(--gray-soft);
+  cursor: pointer;
+  transition: background var(--transition);
+  padding: 0;
+}
+
+.toggle-switch.on {
+  background: var(--accent);
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: white;
+  transition: transform var(--transition);
+}
+
+.toggle-switch.on .toggle-knob {
+  transform: translateX(18px);
+}
+
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.settings-save-btn {
+  padding: 10px 24px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition);
+}
+
+.settings-save-btn:hover {
+  opacity: 0.9;
+}
+
+.settings-saved-msg {
+  font-size: 13px;
+  color: var(--green);
+  font-weight: 500;
+}
+
+.nav-settings {
+  font-size: 18px;
+  line-height: 1;
+}
+
 /* ====== Activity Chart ====== */
 .activity-chart {
   background: var(--glass-bg);


### PR DESCRIPTION
## 变更内容
- /settings 路由 + SettingsPage 组件
- 暗色/亮色主题切换（CSS 变量 + localStorage）
- Webhook 配置（URL + 开关）
- 离线阈值自定义
- 导航栏增加 Settings 入口

## 验收
- [x] tsc + vite build 通过
- [x] 主题切换立即生效
- [x] 配置持久化到 localStorage

Closes #13