### PR TITLE
feat: multi-team support with team switcher (#14)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { TeamProvider } from './components/TeamContext';
 import { TeamOverview } from './pages/TeamOverview';
 import { ChannelView } from './pages/ChannelView';
 import { AgentDetail } from './pages/AgentDetail';
@@ -9,16 +10,18 @@ import { SettingsPage } from './pages/SettingsPage';
 export function App() {
   return (
     <ErrorBoundary>
-      <BrowserRouter>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route index element={<TeamOverview />} />
-            <Route path="channels" element={<ChannelView />} />
-            <Route path="agents/:id" element={<AgentDetail />} />
-            <Route path="settings" element={<SettingsPage />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
+      <TeamProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route element={<Layout />}>
+              <Route index element={<TeamOverview />} />
+              <Route path="channels" element={<ChannelView />} />
+              <Route path="agents/:id" element={<AgentDetail />} />
+              <Route path="settings" element={<SettingsPage />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </TeamProvider>
     </ErrorBoundary>
   );
 }

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -1,10 +1,19 @@
 import type { Agent, Activity, Channel, DashboardData, GitHubSummary } from './types';
 
-const API_BASE = import.meta.env.VITE_API_BASE || '';
-const BASE = `${API_BASE}/api`;
+let _apiBase: string | null = null;
+
+export function setApiBase(base: string) {
+  _apiBase = base;
+}
+
+function getBase(): string {
+  if (_apiBase) return _apiBase;
+  const envBase = import.meta.env.VITE_API_BASE || '';
+  return `${envBase}/api`;
+}
 
 async function get<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE}${path}`);
+  const res = await fetch(`${getBase()}${path}`);
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     throw new Error(`API ${res.status}: ${body || res.statusText}`);

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,10 +1,13 @@
 import { NavLink, Outlet } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { fetchDashboard, fetchHealth } from '../api';
+import { TeamSwitcher } from './TeamSwitcher';
+import { useTeam } from './TeamContext';
 
 export function Layout() {
   const [onlineCount, setOnlineCount] = useState<number | null>(null);
   const [isMock, setIsMock] = useState<boolean | null>(null);
+  const { activeTeam } = useTeam();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -19,7 +22,7 @@ export function Layout() {
     fetchData();
     const id = setInterval(fetchData, 30_000);
     return () => clearInterval(id);
-  }, []);
+  }, [activeTeam]);
 
   return (
     <>
@@ -38,6 +41,7 @@ export function Layout() {
             </NavLink>
           </div>
           <div className="nav-right">
+            <TeamSwitcher />
             {onlineCount !== null && (
               <span className="nav-badge">
                 <span className="dot" />

--- a/packages/web/src/components/TeamContext.tsx
+++ b/packages/web/src/components/TeamContext.tsx
@@ -1,0 +1,113 @@
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
+import type { Team } from '../types';
+import { setApiBase } from '../api';
+
+const TEAMS_KEY = 'claw-teams';
+const ACTIVE_KEY = 'claw-active-team';
+
+function loadTeams(): Team[] {
+  try {
+    const raw = localStorage.getItem(TEAMS_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch { /* ignore */ }
+  return [];
+}
+
+function saveTeams(teams: Team[]) {
+  localStorage.setItem(TEAMS_KEY, JSON.stringify(teams));
+}
+
+function loadActiveId(): string | null {
+  return localStorage.getItem(ACTIVE_KEY);
+}
+
+function saveActiveId(id: string | null) {
+  if (id) {
+    localStorage.setItem(ACTIVE_KEY, id);
+  } else {
+    localStorage.removeItem(ACTIVE_KEY);
+  }
+}
+
+interface TeamContextValue {
+  teams: Team[];
+  activeTeam: Team | null;
+  setActiveTeamId: (id: string) => void;
+  addTeam: (team: Team) => void;
+  updateTeam: (team: Team) => void;
+  removeTeam: (id: string) => void;
+  getApiBase: () => string;
+}
+
+const TeamContext = createContext<TeamContextValue | null>(null);
+
+export function TeamProvider({ children }: { children: ReactNode }) {
+  const [teams, setTeams] = useState<Team[]>(loadTeams);
+  const [activeId, setActiveId] = useState<string | null>(loadActiveId);
+
+  const activeTeam = teams.find(t => t.id === activeId) ?? teams[0] ?? null;
+
+  const setActiveTeamId = useCallback((id: string) => {
+    setActiveId(id);
+    saveActiveId(id);
+  }, []);
+
+  const addTeam = useCallback((team: Team) => {
+    setTeams(prev => {
+      const next = [...prev, team];
+      saveTeams(next);
+      if (prev.length === 0) {
+        setActiveId(team.id);
+        saveActiveId(team.id);
+      }
+      return next;
+    });
+  }, []);
+
+  const updateTeam = useCallback((team: Team) => {
+    setTeams(prev => {
+      const next = prev.map(t => t.id === team.id ? team : t);
+      saveTeams(next);
+      return next;
+    });
+  }, []);
+
+  const removeTeam = useCallback((id: string) => {
+    setTeams(prev => {
+      if (prev.length <= 1) return prev;
+      const next = prev.filter(t => t.id !== id);
+      saveTeams(next);
+      if (activeId === id) {
+        const newActiveId = next[0]?.id ?? null;
+        setActiveId(newActiveId);
+        saveActiveId(newActiveId);
+      }
+      return next;
+    });
+  }, [activeId]);
+
+  const getApiBase = useCallback(() => {
+    if (activeTeam) {
+      const url = activeTeam.gatewayUrl.replace(/\/+$/, '');
+      return `${url}/api`;
+    }
+    const envBase = import.meta.env.VITE_API_BASE || '';
+    return `${envBase}/api`;
+  }, [activeTeam]);
+
+  useEffect(() => {
+    setApiBase(getApiBase());
+  }, [getApiBase]);
+
+  return (
+    <TeamContext.Provider value={{ teams, activeTeam, setActiveTeamId, addTeam, updateTeam, removeTeam, getApiBase }}>
+      {children}
+    </TeamContext.Provider>
+  );
+}
+
+export function useTeam(): TeamContextValue {
+  const ctx = useContext(TeamContext);
+  if (!ctx) throw new Error('useTeam must be used within TeamProvider');
+  return ctx;
+}

--- a/packages/web/src/components/TeamSwitcher.tsx
+++ b/packages/web/src/components/TeamSwitcher.tsx
@@ -1,0 +1,54 @@
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTeam } from './TeamContext';
+
+export function TeamSwitcher() {
+  const { teams, activeTeam, setActiveTeamId } = useTeam();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  if (teams.length === 0) {
+    return (
+      <button className="team-switcher-btn team-switcher-empty" onClick={() => navigate('/settings')}>
+        + Add Team
+      </button>
+    );
+  }
+
+  return (
+    <div className="team-switcher" ref={ref}>
+      <button className="team-switcher-btn" onClick={() => setOpen(!open)}>
+        <span className="team-switcher-name">{activeTeam?.name ?? 'Select Team'}</span>
+        <span className="team-switcher-arrow">{open ? '\u25B4' : '\u25BE'}</span>
+      </button>
+      {open && (
+        <div className="team-switcher-dropdown">
+          {teams.map(t => (
+            <button
+              key={t.id}
+              className={`team-switcher-option ${t.id === activeTeam?.id ? 'active' : ''}`}
+              onClick={() => {
+                setActiveTeamId(t.id);
+                setOpen(false);
+              }}
+            >
+              <span className="team-switcher-option-name">{t.name}</span>
+              {t.id === activeTeam?.id && <span className="team-switcher-check">&#10003;</span>}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+import { useTeam } from '../components/TeamContext';
+import type { Team } from '../types';
 
 type Theme = 'dark' | 'light';
 
@@ -47,6 +49,13 @@ export function SettingsPage() {
   const [threshold, setThreshold] = useState<ThresholdConfig>(getThresholdConfig);
   const [saved, setSaved] = useState(false);
 
+  const { teams, addTeam, updateTeam, removeTeam } = useTeam();
+  const [newTeamName, setNewTeamName] = useState('');
+  const [newTeamUrl, setNewTeamUrl] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editUrl, setEditUrl] = useState('');
+
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
@@ -61,6 +70,104 @@ export function SettingsPage() {
   return (
     <div className="settings-page">
       <h1 className="settings-title">Settings</h1>
+
+      {/* Teams */}
+      <section className="settings-section">
+        <h2 className="settings-section-title">Teams</h2>
+        {teams.length > 0 && (
+          <div className="team-list">
+            {teams.map(t => (
+              <div key={t.id} className="team-item">
+                {editingId === t.id ? (
+                  <div className="team-edit-form">
+                    <input
+                      className="settings-input"
+                      value={editName}
+                      onChange={e => setEditName(e.target.value)}
+                      placeholder="Team name"
+                    />
+                    <input
+                      className="settings-input"
+                      value={editUrl}
+                      onChange={e => setEditUrl(e.target.value)}
+                      placeholder="Gateway URL"
+                    />
+                    <div className="team-edit-actions">
+                      <button
+                        className="team-btn team-btn-save"
+                        onClick={() => {
+                          if (editName.trim() && editUrl.trim()) {
+                            updateTeam({ id: t.id, name: editName.trim(), gatewayUrl: editUrl.trim() });
+                            setEditingId(null);
+                          }
+                        }}
+                      >
+                        Save
+                      </button>
+                      <button className="team-btn team-btn-cancel" onClick={() => setEditingId(null)}>
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="team-item-display">
+                    <div className="team-item-info">
+                      <span className="team-item-name">{t.name}</span>
+                      <span className="team-item-url">{t.gatewayUrl}</span>
+                    </div>
+                    <div className="team-item-actions">
+                      <button
+                        className="team-btn team-btn-edit"
+                        onClick={() => { setEditingId(t.id); setEditName(t.name); setEditUrl(t.gatewayUrl); }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className="team-btn team-btn-delete"
+                        onClick={() => removeTeam(t.id)}
+                        disabled={teams.length <= 1}
+                        title={teams.length <= 1 ? 'At least one team required' : 'Delete team'}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="team-add-form">
+          <input
+            className="settings-input"
+            placeholder="Team name"
+            value={newTeamName}
+            onChange={e => setNewTeamName(e.target.value)}
+          />
+          <input
+            className="settings-input"
+            placeholder="Gateway URL (e.g. http://192.168.1.100:18789)"
+            value={newTeamUrl}
+            onChange={e => setNewTeamUrl(e.target.value)}
+          />
+          <button
+            className="team-btn team-btn-add"
+            disabled={!newTeamName.trim() || !newTeamUrl.trim()}
+            onClick={() => {
+              const team: Team = {
+                id: crypto.randomUUID(),
+                name: newTeamName.trim(),
+                gatewayUrl: newTeamUrl.trim(),
+              };
+              addTeam(team);
+              setNewTeamName('');
+              setNewTeamUrl('');
+            }}
+          >
+            Add Team
+          </button>
+        </div>
+      </section>
 
       {/* Theme */}
       <section className="settings-section">

--- a/packages/web/src/styles/layout.css
+++ b/packages/web/src/styles/layout.css
@@ -111,6 +111,105 @@
   animation: pulse 2s ease-in-out infinite;
 }
 
+/* ====== Team Switcher ====== */
+.team-switcher {
+  position: relative;
+}
+
+.team-switcher-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.team-switcher-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+}
+
+.team-switcher-empty {
+  color: var(--accent);
+  border-color: rgba(99,102,241,0.3);
+}
+
+.team-switcher-empty:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.team-switcher-name {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.team-switcher-arrow {
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+.team-switcher-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 180px;
+  background: var(--bg-card-solid);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  z-index: 200;
+  overflow: hidden;
+}
+
+.team-switcher-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 9px 14px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition);
+  text-align: left;
+}
+
+.team-switcher-option:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.team-switcher-option.active {
+  color: var(--accent);
+}
+
+.team-switcher-option-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.team-switcher-check {
+  font-size: 12px;
+  color: var(--accent);
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
 /* ====== Header Row (refresh, etc) ====== */
 .page-header {
   display: flex;

--- a/packages/web/src/styles/pages.css
+++ b/packages/web/src/styles/pages.css
@@ -460,6 +460,127 @@
   line-height: 1;
 }
 
+/* ====== Team Management (Settings) ====== */
+.team-list {
+  margin-bottom: 14px;
+}
+
+.team-item {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.team-item:last-child {
+  border-bottom: none;
+}
+
+.team-item-display {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.team-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.team-item-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.team-item-url {
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.team-item-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.team-btn {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.team-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.team-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.team-btn-add {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.team-btn-add:hover {
+  opacity: 0.9;
+  background: var(--accent);
+  color: white;
+}
+
+.team-btn-add:disabled {
+  opacity: 0.4;
+}
+
+.team-btn-save {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.team-btn-save:hover {
+  opacity: 0.9;
+  background: var(--accent);
+  color: white;
+}
+
+.team-btn-delete:hover {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.team-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.team-edit-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.team-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 8px;
+}
+
 /* ====== Activity Chart ====== */
 .activity-chart {
   background: var(--glass-bg);

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,3 +1,9 @@
+export interface Team {
+  id: string;
+  name: string;
+  gatewayUrl: string;
+}
+
 export type AgentStatus = 'online' | 'away' | 'busy' | 'error' | 'offline';
 
 export interface Agent {


### PR DESCRIPTION
## 变更内容

### TeamContext + TeamSwitcher
- React Context 管理团队列表和当前活跃团队
- 导航栏下拉切换器，点击即切换
- 无团队时显示添加引导

### SettingsPage 扩展
- 团队管理区域：添加/编辑/删除团队
- 至少保留一个团队（防止全部删除）

### API 适配
- api.ts 新增 setApiBase() 动态切换请求目标
- 向后兼容：无配置时使用 VITE_API_BASE

## 验收
- [x] tsc + vite build 通过 (57 modules)
- [x] 零新依赖
- [x] 向后兼容

Closes #14