### PR TITLE
test(web): add vitest tests for hooks and utils

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "pixi.js": "^8",
@@ -15,10 +17,15 @@
     "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "happy-dom": "^20.8.4",
+    "jsdom": "^29.0.1",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/web/src/hooks.test.ts
+++ b/packages/web/src/hooks.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePolling } from './hooks';
+
+describe('usePolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with loading=true and null data', () => {
+    const fetcher = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => usePolling(fetcher, 5000));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetches data on mount and sets loading=false', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ value: 'hello' });
+    const { result } = renderHook(() => usePolling(fetcher, 60000)); // 60s interval to avoid re-poll
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toEqual({ value: 'hello' });
+    expect(result.current.error).toBeNull();
+    // May be called 1-2 times depending on React strict mode / effect timing
+    expect(fetcher).toHaveBeenCalled();
+  });
+
+  it('sets error when fetcher throws', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('Network error'));
+    const { result } = renderHook(() => usePolling(fetcher, 60000));
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.data).toBeNull();
+  });
+
+  it('handles non-Error throws', async () => {
+    const fetcher = vi.fn().mockRejectedValue('string error');
+    const { result } = renderHook(() => usePolling(fetcher, 60000));
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(result.current.error).toBe('Unknown error');
+  });
+
+  it('refresh() triggers fetch', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+    const { result } = renderHook(() => usePolling(fetcher, 60000));
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    const initialCallCount = fetcher.mock.calls.length;
+
+    // Manual refresh
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(fetcher.mock.calls.length).toBeGreaterThan(initialCallCount);
+  });
+});

--- a/packages/web/src/hooks/useCountUp.test.ts
+++ b/packages/web/src/hooks/useCountUp.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCountUp } from './useCountUp';
+
+describe('useCountUp', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns target directly when target <= 1', () => {
+    const { result, rerender } = renderHook(({ target }) => useCountUp(target), {
+      initialProps: { target: 0 },
+    });
+
+    expect(result.current).toBe(0);
+
+    rerender({ target: 1 });
+    expect(result.current).toBe(1);
+  });
+
+  it('returns large target values', () => {
+    const { result, rerender } = renderHook(({ target }) => useCountUp(target), {
+      initialProps: { target: 100 },
+    });
+
+    // First mount with large value - initial state is target, animation runs
+    expect(result.current).toBe(100);
+
+    rerender({ target: 1000 });
+    expect(result.current).toBe(1000);
+  });
+
+  it('shows value directly on subsequent target changes (no re-animation)', async () => {
+    const { result, rerender } = renderHook(({ target }) => useCountUp(target, 800), {
+      initialProps: { target: 50 },
+    });
+
+    // Change target - should show directly without animation
+    rerender({ target: 200 });
+    expect(result.current).toBe(200);
+  });
+
+  it('cancels animation on unmount', () => {
+    const cancelAnimationFrame = vi.spyOn(window, 'cancelAnimationFrame');
+
+    const { unmount } = renderHook(() => useCountUp(100, 1000));
+
+    unmount();
+
+    // Should have called cancelAnimationFrame during cleanup
+    expect(cancelAnimationFrame).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/test-setup.ts
+++ b/packages/web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/web/src/utils.test.ts
+++ b/packages/web/src/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { timeAgo } from './utils';
+
+describe('timeAgo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "刚刚" for less than 60 seconds', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    vi.setSystemTime(now);
+
+    const result = timeAgo('2024-01-15T11:59:30Z'); // 30 seconds ago
+    expect(result).toBe('刚刚');
+  });
+
+  it('returns minutes for 1-59 minutes ago', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    vi.setSystemTime(now);
+
+    expect(timeAgo('2024-01-15T11:30:00Z')).toBe('30m');
+    expect(timeAgo('2024-01-15T11:01:00Z')).toBe('59m');
+    expect(timeAgo('2024-01-15T11:59:00Z')).toBe('1m');
+  });
+
+  it('returns hours for 1-23 hours ago', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    vi.setSystemTime(now);
+
+    expect(timeAgo('2024-01-15T00:00:00Z')).toBe('12h');
+    expect(timeAgo('2024-01-14T13:00:00Z')).toBe('23h');
+    expect(timeAgo('2024-01-15T11:00:00Z')).toBe('1h');
+  });
+
+  it('returns days for 24+ hours ago', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    vi.setSystemTime(now);
+
+    expect(timeAgo('2024-01-14T12:00:00Z')).toBe('1d');
+    expect(timeAgo('2024-01-13T12:00:00Z')).toBe('2d');
+    expect(timeAgo('2024-01-01T12:00:00Z')).toBe('14d');
+  });
+
+  it('handles ISO strings with timezone offset', () => {
+    const now = new Date('2024-01-15T12:00:00+08:00');
+    vi.setSystemTime(now);
+
+    expect(timeAgo('2024-01-15T11:30:00+08:00')).toBe('30m');
+  });
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    setupFiles: ['./src/test-setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Add vitest configuration for web package
- Add test setup file with jest-dom matchers

## Tests Added
### hooks.test.ts (5 cases)
- `usePolling` starts with loading=true and null data
- `usePolling` fetches data on mount and sets loading=false
- `usePolling` sets error when fetcher throws
- `usePolling` handles non-Error throws
- `usePolling` refresh() triggers fetch

### hooks/useCountUp.test.ts (4 cases)
- Returns target directly when target <= 1
- Returns large target values
- Shows value directly on subsequent target changes
- Cancels animation on unmount

### utils.test.ts (5 cases)
- Returns "刚刚" for < 60 seconds
- Returns minutes for 1-59 minutes
- Returns hours for 1-23 hours
- Returns days for 24+ hours
- Handles ISO strings with timezone offset

## Test Results
- **14 new test cases** for web package
- All tests pass ✅

## Related
- Complements PR #35 (server API tests)
- Part of Issue #30 (add test framework)