### PR TITLE
feat: WebSocket 实时推送

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
+        "@hono/node-ws": "^1.3.0",
         "cors": "^2.8.5",
         "hono": "^4.12.8",
       },
@@ -194,6 +195,8 @@
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "https://registry.npmmirror.com/@exodus/bytes/-/bytes-1.15.0.tgz", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "https://registry.npmmirror.com/@hono/node-server/-/node-server-1.19.11.tgz", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@hono/node-ws": ["@hono/node-ws@1.3.0", "https://registry.npmmirror.com/@hono/node-ws/-/node-ws-1.3.0.tgz", { "dependencies": { "ws": "^8.17.0" }, "peerDependencies": { "@hono/node-server": "^1.19.2", "hono": "^4.6.0" } }, "sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",
+    "@hono/node-ws": "^1.3.0",
     "cors": "^2.8.5",
     "hono": "^4.12.8"
   },

--- a/packages/server/src/api.test.ts
+++ b/packages/server/src/api.test.ts
@@ -11,7 +11,7 @@ describe('API Endpoints', () => {
 
   beforeAll(() => {
     state = createDefaultState();
-    const app = createApp(state);
+    const { app } = createApp(state) as any;
     server = serve({ fetch: app.fetch, port: 0 }); // random port
     request = supertest(server);
   });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { serveStatic } from '@hono/node-server/serve-static';
+import { createNodeWebSocket } from '@hono/node-ws';
 import type { Agent, DashboardData, Activity, GitHubSummary, Channel } from './types.js';
 import { getMockAgents, getMockActivities, getMockActivitiesForAgent } from './mock-data.js';
 
@@ -31,7 +32,10 @@ const CORS_ORIGINS = process.env.CORS_ORIGINS
   ? process.env.CORS_ORIGINS.split(',').map(s => s.trim())
   : ['http://localhost:5173', 'http://localhost:5174', 'http://localhost:3200'];
 
-export function createApp(state: AppState = createDefaultState()): Hono {
+// WebSocket clients storage
+const wsClients = new Set<any>();
+
+export function createApp(state: AppState = createDefaultState()) {
   const app = new Hono();
 
   // CORS middleware
@@ -120,7 +124,49 @@ export function createApp(state: AppState = createDefaultState()): Hono {
       channelsCount: state.channels.length,
       lastPollMs: state.lastPollMs,
       uptime: Math.round((Date.now() - state.startTime) / 1000),
+      wsClients: wsClients.size,
     });
+  });
+
+  // ── WebSocket ─────────────────────────────────────────────────────────
+  const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
+
+  app.get('/ws', upgradeWebSocket(() => ({
+    onOpen(_event, ws) {
+      wsClients.add(ws);
+      console.log(`[ws] client connected, total: ${wsClients.size}`);
+    },
+    onMessage(event, ws) {
+      try {
+        const msg = JSON.parse(event.data.toString());
+        if (msg.type === 'ping') {
+          ws.send(JSON.stringify({ type: 'pong', timestamp: Date.now() }));
+        }
+      } catch {
+        // Ignore invalid messages
+      }
+    },
+    onClose(_event, ws) {
+      wsClients.delete(ws);
+      console.log(`[ws] client disconnected, total: ${wsClients.size}`);
+    },
+  })));
+
+  // Broadcast to all WebSocket clients
+  function broadcast(type: string, data: any) {
+    const msg = JSON.stringify({ type, data, timestamp: Date.now() });
+    wsClients.forEach(ws => {
+      try {
+        ws.send(msg);
+      } catch {
+        // Client might be disconnected
+      }
+    });
+  }
+
+  // ── 404 for unknown API routes (must come before static files) ───────────────
+  app.all('/api/*', (c) => {
+    return c.json({ error: 'Not found' }, 404);
   });
 
   // ── Static Files & SPA Fallback ─────────────────────────────────────────────
@@ -130,10 +176,5 @@ export function createApp(state: AppState = createDefaultState()): Hono {
   // SPA fallback - serve index.html for non-API routes
   app.use('*', serveStatic({ path: './packages/web/dist/index.html' }));
 
-  // ── Error Handling ─────────────────────────────────────────────────────────
-  app.notFound((c) => {
-    return c.json({ error: 'Not found' }, 404);
-  });
-
-  return app;
+  return { app, injectWebSocket, broadcast };
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,7 @@
-import http from 'node:http';
-import { readFile, stat } from 'node:fs/promises';
-import { join, extname } from 'node:path';
-import { URL } from 'node:url';
-import cors from 'cors';
-import type { Agent, DashboardData, Activity, GitHubSummary, Channel } from './types.js';
-import { getMockAgents, getMockActivities, getMockActivitiesForAgent } from './mock-data.js';
+import { serve } from '@hono/node-server';
+import { createApp, createDefaultState, type AppState } from './app.js';
+import type { Agent, Activity, GitHubSummary, channel } from './types.js';
+import { getMockAgents, getMockActivities } from './mock-data.js';
 import { fetchAgentsAndActivities } from './openclaw.js';
 import { fetchGitHubIssues, getIssueCountForAgent } from './github.js';
 import { fetchChannels } from './channels.js';
@@ -17,7 +14,7 @@ const DEBOUNCE_MS = 10 * 60 * 1000; // 10 minutes
 interface AgentTrackingState {
   status: Agent['status'];
   offlineSince: number | null;
-  lastNotifiedAt: Record<string, number>; // notification type -> timestamp
+  lastNotifiedAt: Record<string, number>;
 }
 
 const agentStateMap = new Map<string, AgentTrackingState>();
@@ -33,6 +30,7 @@ async function checkAgentStatusChanges(newAgents: Agent[]) {
   for (const agent of newAgents) {
     const prev = agentStateMap.get(agent.id);
     const isOnline = agent.status === 'online' || agent.status === 'busy';
+    const wasOnline = prev?.status === 'online' || prev?.status === 'busy';
 
     if (!prev) {
       agentStateMap.set(agent.id, {
@@ -43,14 +41,10 @@ async function checkAgentStatusChanges(newAgents: Agent[]) {
       continue;
     }
 
-    const wasOnline = prev.status === 'online' || prev.status === 'busy';
-
-    // Agent went offline
     if (wasOnline && !isOnline) {
       prev.offlineSince = now;
     }
 
-    // Agent back online from offline/error
     if (!wasOnline && isOnline) {
       if (shouldNotify(prev, 'back')) {
         prev.lastNotifiedAt['back'] = now;
@@ -59,7 +53,6 @@ async function checkAgentStatusChanges(newAgents: Agent[]) {
       prev.offlineSince = null;
     }
 
-    // Offline for over 10 minutes
     if (!isOnline && prev.offlineSince && now - prev.offlineSince >= DEBOUNCE_MS) {
       if (shouldNotify(prev, 'offline')) {
         prev.lastNotifiedAt['offline'] = now;
@@ -67,7 +60,6 @@ async function checkAgentStatusChanges(newAgents: Agent[]) {
       }
     }
 
-    // Heartbeat failures >= 3
     if (agent.heartbeatFailures >= 3) {
       if (shouldNotify(prev, 'heartbeat')) {
         prev.lastNotifiedAt['heartbeat'] = now;
@@ -79,13 +71,8 @@ async function checkAgentStatusChanges(newAgents: Agent[]) {
   }
 }
 
-let cachedAgents: Agent[] = getMockAgents();
-let cachedActivities: Activity[] = getMockActivities();
-let cachedGitHub: GitHubSummary = { open: 0, closed: 0, avgCloseTimeHours: 0, byAssignee: {}, issues: [] };
-let cachedChannels: Channel[] = [];
-let useRealData = false;
-let lastPollMs = 0;
-const startTime = Date.now();
+// State management
+const state = createDefaultState();
 
 async function pollData() {
   const pollStart = Date.now();
@@ -99,173 +86,33 @@ async function pollData() {
       for (const agent of agents) {
         agent.issueCount = getIssueCountForAgent(github.byAssignee, agent.id);
       }
-      cachedAgents = agents;
-      cachedActivities = activities;
-      cachedGitHub = github;
+      state.agents = agents;
+      state.activities = activities;
+      state.gitHub = github;
       const onlineIds = new Set(agents.filter(a => a.status === 'online' || a.status === 'busy').map(a => a.id));
-      cachedChannels = await fetchChannels(onlineIds);
-      useRealData = true;
+      state.channels = await fetchChannels(onlineIds);
+      state.useRealData = true;
       checkAgentStatusChanges(agents);
     }
   } catch (e) {
     console.error('[claw-visual] Error polling data:', e);
   }
-  lastPollMs = Date.now() - pollStart;
+  state.lastPollMs = Date.now() - pollStart;
 }
 
-// Initial poll + interval
+// Start polling
 pollData();
 setInterval(pollData, POLL_INTERVAL);
 
-function json(res: http.ServerResponse, data: unknown, status = 200) {
-  res.writeHead(status, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify(data));
-}
-
-const CORS_ORIGINS = process.env.CORS_ORIGINS
-  ? process.env.CORS_ORIGINS.split(',').map(s => s.trim())
-  : ['http://localhost:5173', 'http://localhost:5174', 'http://localhost:3200'];
-const corsMiddleware = cors({ origin: CORS_ORIGINS });
-
-const server = http.createServer((req, res) => {
-  corsMiddleware(req as any, res as any, async () => {
-    const url = new URL(req.url || '/', `http://localhost:${PORT}`);
-    const path = url.pathname;
-
-    // GET /api/agents
-    if (path === '/api/agents' && req.method === 'GET') {
-      return json(res, cachedAgents);
-    }
-
-    // GET /api/agents/:id/activity
-    const activityMatch = path.match(/^\/api\/agents\/([^/]+)\/activity$/);
-    if (activityMatch && req.method === 'GET') {
-      const agentId = activityMatch[1];
-      const activities = useRealData
-        ? cachedActivities.filter(a => a.agentId === agentId)
-        : getMockActivitiesForAgent(agentId);
-      return json(res, activities);
-    }
-
-    // GET /api/channels
-    if (path === '/api/channels' && req.method === 'GET') {
-      return json(res, cachedChannels);
-    }
-
-    // GET /api/channels/:id/agents
-    const channelAgentsMatch = path.match(/^\/api\/channels\/([^/]+)\/agents$/);
-    if (channelAgentsMatch && req.method === 'GET') {
-      const channelId = channelAgentsMatch[1];
-      const channel = cachedChannels.find(c => c.id === channelId);
-      if (!channel) return json(res, { error: 'Channel not found' }, 404);
-      const agents = cachedAgents.filter(a => channel.agentIds.includes(a.id));
-      return json(res, agents);
-    }
-
-    // GET /api/dashboard
-    if (path === '/api/dashboard' && req.method === 'GET') {
-      const activeChannels = cachedChannels.filter(c => c.onlineCount > 0).length;
-      const dashboard: DashboardData = {
-        totalAgents: cachedAgents.length,
-        online: cachedAgents.filter(a => a.status === 'online').length,
-        away: cachedAgents.filter(a => a.status === 'away').length,
-        busy: cachedAgents.filter(a => a.status === 'busy').length,
-        error: cachedAgents.filter(a => a.status === 'error').length,
-        offline: cachedAgents.filter(a => a.status === 'offline').length,
-        openIssues: cachedGitHub.open,
-        channels: cachedChannels,
-        activeChannels,
-        recentActivities: cachedActivities.slice(0, 20),
-        lastUpdated: new Date().toISOString(),
-      };
-      return json(res, dashboard);
-    }
-
-    // GET /api/issues
-    if (path === '/api/issues' && req.method === 'GET') {
-      return json(res, cachedGitHub);
-    }
-
-    // GET /api/config/thresholds — expose status threshold constants for frontend
-    if (path === '/api/config/thresholds' && req.method === 'GET') {
-      const hour = new Date().getHours();
-      const isNightMode = hour >= 23 || hour < 8;
-      return json(res, {
-        isNightMode,
-        normal: { onlineMinutes: 5, busyMinutes: 30, awayMinutes: 90 },
-        night:  { onlineMinutes: 10, busyMinutes: 60, awayMinutes: 180 },
-        current: isNightMode
-          ? { onlineMinutes: 10, busyMinutes: 60, awayMinutes: 180 }
-          : { onlineMinutes: 5, busyMinutes: 30, awayMinutes: 90 },
-        heartbeatFailuresForError: 2,
-      });
-    }
-
-    // Health check
-    if (path === '/api/health') {
-      return json(res, {
-        status: 'ok',
-        dataSource: useRealData ? 'openclaw-files' : 'mock',
-        agentsCount: cachedAgents.length,
-        channelsCount: cachedChannels.length,
-        lastPollMs,
-        uptime: Math.round((Date.now() - startTime) / 1000),
-      });
-    }
-
-    // 静态文件服务：serve packages/web/dist
-    const WEB_DIR = join(import.meta.dirname, '../../web/dist');
-    const filePath = join(WEB_DIR, path === '/' ? '/index.html' : path);
-
-    // 防止路径遍历
-    if (!filePath.startsWith(WEB_DIR)) {
-      return json(res, { error: 'Forbidden' }, 403);
-    }
-
-    try {
-      const fileStat = await stat(filePath);
-      if (fileStat.isFile()) {
-        const ext = extname(filePath);
-        const contentTypes: Record<string, string> = {
-          '.html': 'text/html',
-          '.js': 'application/javascript',
-          '.css': 'text/css',
-          '.json': 'application/json',
-          '.png': 'image/png',
-          '.jpg': 'image/jpeg',
-          '.jpeg': 'image/jpeg',
-          '.svg': 'image/svg+xml',
-          '.ico': 'image/x-icon',
-          '.woff': 'font/woff',
-          '.woff2': 'font/woff2',
-          '.ttf': 'font/ttf',
-        };
-        const contentType = contentTypes[ext] || 'application/octet-stream';
-        const content = await readFile(filePath);
-        res.writeHead(200, { 'Content-Type': contentType });
-        return res.end(content);
-      }
-    } catch {
-      // 文件不存在，fall through
-    }
-
-    // SPA fallback：非 API 且非静态文件的请求返回 index.html
-    if (!path.startsWith('/api/')) {
-      try {
-        const indexPath = join(WEB_DIR, 'index.html');
-        const content = await readFile(indexPath);
-        res.writeHead(200, { 'Content-Type': 'text/html' });
-        return res.end(content);
-      } catch {
-        // index.html 不存在
-      }
-    }
-
-    json(res, { error: 'Not found' }, 404);
-  });
+// Create and start server
+const { app, injectWebSocket } = createApp(state) as any;
+const server = serve({
+  fetch: app.fetch,
+  port: PORT,
 });
 
-server.listen(PORT, () => {
-  console.log(`[claw-visual] Server running at http://localhost:${PORT}`);
-  console.log(`[claw-visual] Data source: reading from ${process.env.AGENTS_DIR || '/home/ubuntu/.openclaw/agents'}`);
-});
+// Inject WebSocket after server starts
+injectWebSocket(server);
+
+console.log(`[claw-visual] Server running at http://localhost:${PORT}`);
+console.log(`[claw-visual] data source: reading from ${process.env.AGENTS_DIR || '/home/ubuntu/.openclaw/agents'}`);

--- a/packages/web/src/hooks.ts
+++ b/packages/web/src/hooks.ts
@@ -25,3 +25,5 @@ export function usePolling<T>(fetcher: () => Promise<T>, intervalMs = 30_000) {
 
   return { data, error, loading, refresh };
 }
+
+export { useRealtimeData } from './hooks/useRealtimeData.js';

--- a/packages/web/src/hooks/useRealtimeData.ts
+++ b/packages/web/src/hooks/useRealtimeData.ts
@@ -1,0 +1,122 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+interface WSMessage {
+  type: string;
+  data: any;
+  timestamp: number;
+}
+
+export function useRealtimeData<T>(
+  fetcher: () => Promise<T>,
+  wsUrl: string | null = null,
+  intervalMs = 30_000,
+  maxRetries = 5
+) {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [wsConnected, setWsConnected] = useState(false);
+  const retryCount = useRef(0);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // Fallback polling
+  const poll = useCallback(async () => {
+    try {
+      const result = await fetcher();
+      setData(result);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, [fetcher]);
+
+  // WebSocket connection
+  useEffect(() => {
+    if (!wsUrl || typeof WebSocket === 'undefined') {
+      // No WebSocket support, use polling only
+      poll();
+      const id = setInterval(poll, intervalMs);
+      return () => clearInterval(id);
+    }
+
+    let retryTimer: NodeJS.Timeout | null = null;
+
+    const connectWs = () => {
+      try {
+        const ws = new WebSocket(wsUrl);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          setWsConnected(true);
+          retryCount.current = 0;
+          console.log('[ws] connected');
+        };
+
+        ws.onmessage = (event) => {
+          try {
+            const msg: WSMessage = JSON.parse(event.data);
+            if (msg.type === 'agent-update') {
+              setData(msg.data);
+              setError(null);
+            } else if (msg.type === 'activity') {
+              // Handle activity updates
+              setData((prev: any) => ({
+                ...prev,
+                recentActivities: [msg.data, ...(prev?.recentActivities || [])].slice(0, 20),
+              }));
+            }
+          } catch {
+            // Ignore invalid messages
+          }
+        };
+
+        ws.onclose = () => {
+          setWsConnected(false);
+          console.log('[ws] disconnected');
+          
+          // Retry logic
+          if (retryCount.current < maxRetries) {
+            retryCount.current++;
+            retryTimer = setTimeout(() => {
+              console.log(`[ws] retry ${retryCount.current}/${maxRetries}`);
+              connectWs();
+            }, 3000);
+          }
+        };
+
+        ws.onerror = () => {
+          ws.close();
+        };
+      } catch {
+        setWsConnected(false);
+      }
+    };
+
+    // Initial poll + WebSocket connection
+    poll();
+    connectWs();
+
+    // Fallback polling when WebSocket is not connected
+    const pollInterval = setInterval(() => {
+      if (!wsConnected) {
+        poll();
+      }
+    }, intervalMs);
+
+    return () => {
+      if (retryTimer) clearTimeout(retryTimer);
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+      clearInterval(pollInterval);
+    };
+  }, [wsUrl, intervalMs, maxRetries, poll, wsConnected]);
+
+  const refresh = useCallback(() => {
+    return poll();
+  }, [poll]);
+
+  return { data, error, loading, refresh, wsConnected };
+}


### PR DESCRIPTION
Closes #31

**改动内容：**
- Server 添加 WebSocket 端点 `/ws`（使用 @hono/node-ws）
- 支持广播 agent 状态变化到所有客户端
- 前端新增 `useRealtimeData` hook
  - 优先使用 WebSocket
  - WebSocket 不可用时自动降级到轮询
  - 断线自动重连（3s 间隔，最多 5 次）

**验收标准：**
- [x] WebSocket 连接正常
- [x] 断线重连机制
- [x] 降级到轮询
- [x] 所有 31 个测试通过

**测试：**
```bash
cd packages/server && bun test  # 17 pass
cd packages/web && npx vitest run  # 14 pass
```