### PR TITLE
feat(web): Agent 详情页增强 + 未初始化 Agent 优化

### DIFF
--- a/packages/server/src/mock-data.ts
+++ b/packages/server/src/mock-data.ts
@@ -65,6 +65,40 @@ export function getMockAgents(): Agent[] {
       pendingTasks: 0,
       heartbeatFailures: 0,
     },
+    // 未初始化的 agents（无 IDENTITY.md）
+    {
+      id: 'jiangong',
+      name: '',
+      role: '',
+      status: 'offline',
+      lastSeen: minutesAgo(300),
+      avatar: '',
+      pendingTasks: 0,
+      heartbeatFailures: 0,
+      uninitialized: true,
+    },
+    {
+      id: 'meishu',
+      name: '',
+      role: '',
+      status: 'offline',
+      lastSeen: minutesAgo(400),
+      avatar: '',
+      pendingTasks: 0,
+      heartbeatFailures: 0,
+      uninitialized: true,
+    },
+    {
+      id: 'xiaozhi',
+      name: '',
+      role: '',
+      status: 'offline',
+      lastSeen: minutesAgo(500),
+      avatar: '',
+      pendingTasks: 0,
+      heartbeatFailures: 0,
+      uninitialized: true,
+    },
   ];
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -11,6 +11,7 @@ export interface Agent {
   heartbeatFailures: number;
   lastActivity?: string | null;
   issueCount?: number;
+  uninitialized?: boolean;
 }
 
 export interface Activity {

--- a/packages/web/src/components/ActivityHeatmap.tsx
+++ b/packages/web/src/components/ActivityHeatmap.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import type { Activity } from '../types';
+
+interface Props {
+  activities: Activity[];
+}
+
+interface HourlyActivity {
+  hour: number;
+  count: number;
+  level: number; // 0-4
+}
+
+function aggregateByHourOfDay(activities: Activity[]): HourlyActivity[] {
+  const counts = new Array(24).fill(0);
+
+  for (const a of activities) {
+    const hour = new Date(a.timestamp).getHours();
+    counts[hour]++;
+  }
+
+  const max = Math.max(...counts, 1);
+  const levels = counts.map(count => {
+    if (count === 0) return 0;
+    const ratio = count / max;
+    if (ratio < 0.25) return 1;
+    if (ratio < 0.5) return 2;
+    if (ratio < 0.75) return 3;
+    return 4;
+  });
+
+  return counts.map((count, hour) => ({
+    hour,
+    count,
+    level: levels[hour],
+  }));
+}
+
+const HOUR_LABELS = [
+  '0时', '1时', '2时', '3时', '4时', '5时',
+  '6时', '7时', '8时', '9时', '10时', '11时',
+  '12时', '13时', '14时', '15时', '16时', '17时',
+  '18时', '19时', '20时', '21时', '22时', '23时',
+];
+
+export function ActivityHeatmap({ activities }: Props) {
+  const hourlyData = useMemo(() => aggregateByHourOfDay(activities), [activities]);
+
+  return (
+    <div className="activity-heatmap">
+      <h2 className="section-title">活跃度热力图</h2>
+      <div className="heatmap-grid">
+        {hourlyData.map(({ hour, count, level }) => (
+          <div
+            key={hour}
+            className={`heatmap-cell level-${level}`}
+            title={`${HOUR_LABELS[hour]} - ${count} 次活动`}
+          >
+            <span className="heatmap-hour">{hour}</span>
+          </div>
+        ))}
+      </div>
+      <div className="heatmap-legend">
+        <span className="legend-label">少</span>
+        {[0, 1, 2, 3, 4].map(level => (
+          <div key={level} className={`legend-cell level-${level}`} />
+        ))}
+        <span className="legend-label">多</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/AgentCard.tsx
+++ b/packages/web/src/components/AgentCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useMemo } from 'react';
 import type { Agent } from '../types';
 import { timeAgo } from '../utils';
 import { StatusBadge } from './StatusBadge';
@@ -46,22 +46,67 @@ function useTilt() {
   return { cardRef, handleMouseMove, handleMouseLeave };
 }
 
+/**
+ * Generate stable gradient color from agent id.
+ * Used for uninitialized agents without avatar.
+ */
+function useAgentGradient(id: string) {
+  return useMemo(() => {
+    // Hash the id to get consistent colors
+    let hash = 0;
+    for (let i = 0; i < id.length; i++) {
+      const char = id.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash;
+    }
+
+    // Generate two colors from the hash
+    const hue1 = Math.abs(hash % 360);
+    const hue2 = (hue1 + 40) % 360;
+
+    return `linear-gradient(135deg, hsl(${hue1}, 70%, 50%), hsl(${hue2}, 70%, 50%))`;
+  }, [id]);
+}
+
 export function AgentCard({ agent }: { agent: Agent }) {
   const { cardRef, handleMouseMove, handleMouseLeave } = useTilt();
+  const gradient = useAgentGradient(agent.id);
+
+  const displayName = agent.uninitialized || !agent.name
+    ? agent.id
+    : agent.name;
+
+  const displayRole = agent.uninitialized || !agent.role
+    ? '未配置'
+    : agent.role;
+
+  const displayAvatar = agent.uninitialized || !agent.avatar
+    ? agent.id.charAt(0).toUpperCase()
+    : agent.avatar;
 
   return (
     <Link
       to={`/agents/${agent.id}`}
-      className="agent-card"
+      className={`agent-card ${agent.uninitialized ? 'agent-card--uninitialized' : ''}`}
       ref={cardRef}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
       <div className="agent-card-header">
-        <div className={`agent-avatar ${agent.status}`}>{agent.avatar}</div>
+        <div
+          className={`agent-avatar ${agent.status}`}
+          style={agent.uninitialized ? { background: gradient } : undefined}
+        >
+          {displayAvatar}
+        </div>
         <div className="agent-info">
-          <h3>{agent.name}</h3>
-          {agent.role && <span className="role">{agent.role}</span>}
+          <h3>
+            {displayName}
+            {agent.uninitialized && <span className="uninitialized-badge">未配置</span>}
+          </h3>
+          <span className={`role ${agent.uninitialized ? 'role--uninitialized' : ''}`}>
+            {displayRole}
+          </span>
         </div>
       </div>
       {agent.lastActivity && (

--- a/packages/web/src/pages/AgentDetail.tsx
+++ b/packages/web/src/pages/AgentDetail.tsx
@@ -6,6 +6,42 @@ import { ActivityChart } from '../components/ActivityChart';
 import { StaggerIn } from '../components/StaggerIn';
 import type { Agent, Activity, AgentStatus } from '../types';
 
+/**
+ * Generate a stable gradient color based on agent id
+ * Uses a hash function to create consistent colors
+ */
+function generateGradientColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = id.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue1 = Math.abs(hash % 360);
+  const hue2 = (hue1 + 40) % 360;
+  return `linear-gradient(135deg, hsl(${hue1}, 70%, 50%), hsl(${hue2}, 70%, 40%)`;
+}
+
+/**
+ * Get display name for agent
+ * Returns agent name or "id (未配置)" for uninitialized agents
+ */
+function getDisplayName(agent: Agent): string {
+  if (agent.uninitialized || !agent.name) {
+    return `${agent.id} (未配置)`;
+  }
+  return agent.name;
+}
+
+/**
+ * Get avatar initials for agent
+ * Uses first letter of id for uninitialized agents
+ */
+function getAvatarInitials(agent: Agent): string {
+  if (agent.uninitialized || !agent.avatar) {
+    return agent.id.charAt(0).toUpperCase();
+  }
+  return agent.avatar;
+}
+
 const STATUS_LABELS: Record<AgentStatus, string> = {
   online: '在线',
   away: '离开',
@@ -222,19 +258,33 @@ export function AgentDetail() {
       {/* Hero */}
       <div className="detail-hero">
         <div className="detail-avatar-wrapper">
-          <div className={`detail-avatar-lg ${agent.status}`}>
-            {agent.avatar}
+          <div
+            className={`detail-avatar-lg ${agent.status} ${agent.uninitialized ? 'uninitialized' : ''}`}
+            style={agent.uninitialized ? { background: generateGradientColor(agent.id) } : {}}
+          >
+            {getAvatarInitials(agent)}
           </div>
         </div>
         <div className="detail-hero-info">
           <div className="detail-hero-name">
-            <h1>{agent.name}</h1>
+            <h1>{getDisplayName(agent)}</h1>
+            {agent.uninitialized && (
+              <span className="uninitialized-badge">未配置</span>
+            )}
             <span className={`status-badge ${agent.status}`}>
               <span className="dot" />
               {STATUS_LABELS[agent.status]}
             </span>
           </div>
-          <p className="detail-role">{agent.role}</p>
+          <p className={`detail-role ${agent.uninitialized ? 'role--uninitialized' : ''}`}>
+            {agent.uninitialized ? '尚未配置 IDENTITY.md' : agent.role}
+          </p>
+          {agent.uninitialized && (
+            <div className="uninitialized-hint">
+              <p>该 Agent 尚未配置 IDENTITY.md 文件，无法显示完整信息。</p>
+              <p className="hint-secondary">配置后将显示角色描述、活动统计等详细信息。</p>
+            </div>
+          )}
           <div className="detail-meta">
             <span>最后活跃：{timeAgo(agent.lastSeen)}</span>
             {agent.issueCount !== undefined && agent.issueCount > 0 && (
@@ -285,6 +335,19 @@ export function AgentDetail() {
           </div>
         )}
       </div>
+
+      {/* Uninitialized Hint */}
+      {agent.uninitialized && (
+        <div className="detail-section uninitialized-hint">
+          <div className="hint-icon">⚠️</div>
+          <p>
+            <strong>{agent.id}</strong> 尚未配置 IDENTITY.md
+          </p>
+          <p className="hint-secondary">
+            该 Agent 暂无法显示完整信息，配置后将显示角色描述。
+          </p>
+        </div>
+      )}
 
       {/* Status History */}
       {statusHistory.length > 0 && (

--- a/packages/web/src/styles/components.css
+++ b/packages/web/src/styles/components.css
@@ -767,3 +767,128 @@
     flex-shrink: 0;
   }
 }
+
+/* ====== Uninitialized Agent ====== */
+.agent-card--uninitialized {
+  opacity: 0.8;
+}
+
+.agent-card--uninitialized .agent-info h3 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.uninitialized-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgba(255, 159, 64, 0.15);
+  color: var(--orange);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.role--uninitialized {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ====== Activity Heatmap ====== */
+.activity-heatmap {
+  margin-bottom: 24px;
+}
+
+.heatmap-grid {
+  display: grid;
+  grid-template-columns: repeat(24, 1fr);
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.heatmap-cell {
+  aspect-ratio: 1;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.heatmap-cell.level-0 { background: var(--gray-soft); opacity: 0.3; }
+.heatmap-cell.level-1 { background: rgba(34, 197, 94, 0.2); }
+.heatmap-cell.level-2 { background: rgba(34, 197, 94, 0.4); }
+.heatmap-cell.level-3 { background: rgba(34, 197, 94, 0.6); }
+.heatmap-cell.level-4 { background: rgba(34, 197, 94, 0.8); color: white; }
+
+.heatmap-cell:hover {
+  transform: scale(1.2);
+  z-index: 1;
+}
+
+.heatmap-hour {
+  opacity: 0.7;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.legend-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.legend-cell {
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+}
+
+.legend-cell.level-0 { background: var(--gray-soft); opacity: 0.3; }
+.legend-cell.level-1 { background: rgba(34, 197, 94, 0.2); }
+.legend-cell.level-2 { background: rgba(34, 197, 94, 0.4); }
+.legend-cell.level-3 { background: rgba(34, 197, 94, 0.6); }
+.legend-cell.level-4 { background: rgba(34, 197, 94, 0.8); }
+
+@media (max-width: 768px) {
+  .heatmap-grid {
+    grid-template-columns: repeat(12, 1fr);
+  }
+
+  .heatmap-cell:nth-child(n+13) {
+    display: none;
+  }
+}
+
+/* ====== Uninitialized Agent Hint ====== */
+.uninitialized-hint {
+  margin-top: 8px;
+  padding: 12px 16px;
+  background: rgba(255, 159, 64, 0.08);
+  border-left: 3px solid var(--orange);
+  border-radius: 4px;
+}
+
+.uninitialized-hint p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.uninitialized-hint .hint-secondary {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -17,6 +17,7 @@ export interface Agent {
   heartbeatFailures: number;
   lastActivity?: string | null;
   issueCount?: number;
+  uninitialized?: boolean;
 }
 
 export interface Activity {


### PR DESCRIPTION
完成 Issue #32 Phase 2.3

**未初始化 Agent 夋理：**
- 无名称时显示 agent id + "(未配置)" 标签
- 头像用 agent id 生成稳定的渐变色背景
- 卡片/详情页显示提示：该 Agent 尚未配置 IDENTITY.md

**Agent 详情页增强:**
- 显示未初始化 agent 的友好提示
- 准备活跃度热力图组件
- 优化未初始化 agent 的视觉反馈

**验收:**
- 所有 agent 都有合理的显示
- 详情页信息密度提升

- 关联的 GitHub Issues 待后续实现

**负责人:** @小开