### PR TITLE
fix: PixelOffice 崩溃修复 + 遗留清理

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,6 @@
     "hono": "^4.12.8"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.17",
     "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.2",
     "supertest": "^7.2.2",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,6 @@
 import { serve } from '@hono/node-server';
 import { createApp, createDefaultState, type AppState } from './app.js';
-import type { Agent, Activity, GitHubSummary, channel } from './types.js';
+import type { Agent, Activity, GitHubSummary, Channel } from './types.js';
 import { getMockAgents, getMockActivities } from './mock-data.js';
 import { fetchAgentsAndActivities } from './openclaw.js';
 import { fetchGitHubIssues, getIssueCountForAgent } from './github.js';

--- a/packages/web/src/pixel/AgentSprite.ts
+++ b/packages/web/src/pixel/AgentSprite.ts
@@ -266,10 +266,10 @@ export class AgentSprite {
     this.container.scale.y = this.container.scale.x;
 
     // Idle breathing animation for online agents at desk
-    if (this.isAtDesk && this.agent.status !== 'offline') {
+    if (this.isAtDesk && this.agent.status !== 'offline' && this.animated) {
       this.breathePhase += 0.05;
       // Gentle horizontal sway (1-2px)
-      this.animated!.x = Math.sin(this.breathePhase) * 1.5;
+      this.animated.x = Math.sin(this.breathePhase) * 1.5;
     }
 
     // Error overlay blink
@@ -304,11 +304,11 @@ export class AgentSprite {
     const sheet = this.animated.texture.source;
     // Re-fetch from cache
     getSheet(resolveSpritePath(this.agentKey)).then((s) => {
-      if (this.destroyed) return;
+      if (this.destroyed || !this.animated) return;
       const textures = s.animations[state] ?? s.animations['idle'];
-      this.animated!.textures = textures;
-      this.animated!.animationSpeed = ANIM_SPEED[state];
-      this.animated!.play();
+      this.animated.textures = textures;
+      this.animated.animationSpeed = ANIM_SPEED[state];
+      this.animated.play();
     });
   }
 


### PR DESCRIPTION
**P0 Bug Fix:**
- `AgentSprite.tick()` 中 `this.animated` 为 null 时崩溃 (Cannot set properties of null setting 'x')
- 原因：sprite sheet 异步加载未完成时，tick 已被调用
- 修复：添加 null guard

**遗留清理：**
- `index.ts` 第 3 行 `channel` → `Channel` typo
- 移除 `@types/cors`（cors 包已在 PR #39 中移除）

17 个 server 测试通过 ✅