### PR TITLE
feat(web): Pixel Office 主题切换功能

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
         "hono": "^4.12.8",
       },
       "devDependencies": {
-        "@types/cors": "^2.8.17",
         "@types/node": "^22.0.0",
         "@types/supertest": "^6.0.2",
         "supertest": "^7.2.2",
@@ -296,8 +295,6 @@
     "@types/chai": ["@types/chai@5.2.3", "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/cookiejar": ["@types/cookiejar@2.1.5", "https://registry.npmmirror.com/@types/cookiejar/-/cookiejar-2.1.5.tgz", {}, "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="],
-
-    "@types/cors": ["@types/cors@2.8.19", "https://registry.npmmirror.com/@types/cors/-/cors-2.8.19.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 

--- a/packages/web/src/pages/PixelOffice.tsx
+++ b/packages/web/src/pages/PixelOffice.tsx
@@ -1,8 +1,16 @@
 import { useRef, useEffect, useCallback, useState } from 'react';
 import { fetchAgents } from '../api';
 import { usePolling } from '../hooks';
-import { PixiApp } from '../pixel/PixiApp';
+import { PixiApp, type OfficeTheme } from '../pixel/PixiApp';
 import type { Agent } from '../types';
+
+const THEME_LABELS: Record<OfficeTheme, string> = {
+  auto: '自动',
+  day: '白天',
+  night: '夜晚',
+  dusk: '黄昏',
+  holiday: '节日',
+};
 
 // ── Agent info popup ─────────────────────────────────────────────────────────
 const STATUS_DISPLAY: Record<Agent['status'], { label: string; color: string }> = {
@@ -108,6 +116,14 @@ export function PixelOffice() {
   const pendingAgentsRef = useRef<Agent[] | null>(null);
   const [initError, setInitError] = useState<string | null>(null);
   const [popup, setPopup] = useState<{ agent: Agent; x: number; y: number } | null>(null);
+  const [theme, setTheme] = useState<OfficeTheme>('auto');
+
+  // Apply theme to PixiApp
+  useEffect(() => {
+    if (pixiRef.current?.isReady()) {
+      pixiRef.current.setTheme(theme);
+    }
+  }, [theme]);
 
   const agentsFetcher = useCallback(() => fetchAgents(), []);
   const { data: agents, error } = usePolling<Agent[]>(agentsFetcher);
@@ -162,18 +178,43 @@ export function PixelOffice() {
 
   return (
     <div>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 8 }}>
-        <h2 className="section-title" style={{
-          margin: 0,
-          fontFamily: 'monospace',
-          letterSpacing: '1px',
-          textShadow: '2px 2px 0 #3a3a50',
-        }}>🎮 像素办公室</h2>
-        {agents && (
-          <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
-            {agents.length} agents · 在线 {agents.filter((a) => a.status === 'online' || a.status === 'busy').length}
-          </span>
-        )}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8, flexWrap: 'wrap', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+          <h2 className="section-title" style={{
+            margin: 0,
+            fontFamily: 'monospace',
+            letterSpacing: '1px',
+            textShadow: '2px 2px 0 #3a3a50',
+          }}>🎮 像素办公室</h2>
+          {agents && (
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+              {agents.length} agents · 在线 {agents.filter((a) => a.status === 'online' || a.status === 'busy').length}
+            </span>
+          )}
+        </div>
+
+        {/* Theme Switcher */}
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>主题：</span>
+          {(Object.keys(THEME_LABELS) as OfficeTheme[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTheme(t)}
+              style={{
+                padding: '4px 10px',
+                fontSize: 12,
+                border: theme === t ? '1px solid var(--accent)' : '1px solid var(--glass-border)',
+                borderRadius: 4,
+                background: theme === t ? 'var(--accent-soft)' : 'transparent',
+                color: theme === t ? 'var(--accent)' : 'var(--text-secondary)',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+              }}
+            >
+              {THEME_LABELS[t]}
+            </button>
+          ))}
+        </div>
       </div>
 
       {error && <div className="error-msg">数据加载失败：{error}</div>}

--- a/packages/web/src/pixel/PixiApp.ts
+++ b/packages/web/src/pixel/PixiApp.ts
@@ -7,6 +7,9 @@ import { assignFixedSlots, SCENE_W, SCENE_H } from './SceneLayout';
 /** Callback when an agent sprite is clicked */
 export type AgentClickHandler = (agent: Agent, canvasX: number, canvasY: number) => void;
 
+/** Office theme options */
+export type OfficeTheme = 'auto' | 'day' | 'night' | 'dusk' | 'holiday';
+
 export class PixiApp {
   private app: Application | null = null;
   private sprites: Map<string, AgentSprite> = new Map();
@@ -18,6 +21,7 @@ export class PixiApp {
   private colorFilter: ColorMatrixFilter | null = null;
   private dayNightTimer = 0;
   private onAgentClick: AgentClickHandler | null = null;
+  private currentTheme: OfficeTheme = 'auto';
 
   setClickHandler(handler: AgentClickHandler) {
     this.onAgentClick = handler;
@@ -93,6 +97,35 @@ export class PixiApp {
       this.colorFilter.tint(0xffcc88, false);
     }
     // Daytime: no filter change (neutral)
+  }
+
+  /** Set office theme */
+  setTheme(theme: OfficeTheme) {
+    if (!this.colorFilter) return;
+    this.currentTheme = theme;
+    this.colorFilter.reset();
+
+    switch (theme) {
+      case 'auto':
+        this.applyDayNight();
+        break;
+      case 'day':
+        // No filter - full brightness
+        break;
+      case 'night':
+        this.colorFilter.brightness(0.55, false);
+        this.colorFilter.tint(0x8899cc, false);
+        break;
+      case 'dusk':
+        this.colorFilter.brightness(0.85, false);
+        this.colorFilter.tint(0xffcc88, false);
+        break;
+      case 'holiday':
+        this.colorFilter.brightness(0.9, false);
+        this.colorFilter.hue(30, false);
+        this.colorFilter.saturate(1.2, false);
+        break;
+    }
   }
 
   isReady(): boolean {


### PR DESCRIPTION
完成 Issue #33 Phase 2.4 - Pixel Office 交互增强

**主题切换：**
- 支持 5 种主题：自动、白天、夜晚、黄昏、节日
- 自动模式根据时间自动切换白天/黄昏/夜晚
- 主题切换 UI 在页面右上角

**验收：**
- 点击角色有响应（弹出信息卡）✅
- 主题切换功能 ✅

**测试：**
- Server: 17 pass
- Web: 14 pass