### PR TITLE
feat(web): 游戏化基础 - useGamification hook + Leaderboard 组件

### DIFF
--- a/docs/gamification-spec.md
+++ b/docs/gamification-spec.md
@@ -1,0 +1,66 @@
+# #57 游戏化设计方案
+
+## 积分规则（按小后建议）
+
+| Agent 状态 | 积分/5min | 说明 |
+|-----------|-----------|------|
+| busy | +2 | 正在处理任务 |
+| online | +1 | 正常在线工作 |
+| away | 0 | 离开，0积分 |
+| offline | 0 | 下线，0积分 |
+| error | -1 | 异常状态，扣分 |
+
+| 额外积分 | 分值 | 说明 |
+|---------|------|------|
+| 每处理1个issue | +5 | GitHub issues 关闭 |
+
+**积分计算：** 每30秒 WebSocket 推送时，根据当前状态计算增量
+
+## 数据结构
+
+```typescript
+interface AgentScore {
+  agentId: string;
+  agentName: string;
+  totalScore: number;
+  busyMinutes: number;
+  onlineMinutes: number;
+  errorMinutes: number;
+  issuesResolved: number;
+  lastUpdated: number;
+}
+
+interface LeaderboardEntry {
+  rank: number;
+  agentId: string;
+  agentName: string;
+  score: number;
+  status: AgentStatus;
+}
+```
+
+## 排行榜 UI 方案
+
+**位置：** 侧边栏底部，或者浮层面板（可展开/收起）
+
+**显示内容：**
+- 前3名：金色/银色/铜牌图标 + 名字 + 积分
+- 其余：排名 + 名字 + 积分 + 状态徽章
+
+**交互：**
+- 点击条目 → 高亮对应 AgentSprite
+- 悬停 → 显示详细统计（在线时长、忙碌时长）
+
+**样式：** 像素风格卡片，排名数字大号显示
+
+## 实现位置
+
+- `packages/web/src/hooks/useGamification.ts` — 积分计算 hook
+- `packages/web/src/components/Leaderboard.tsx` — 排行榜组件
+- `packages/web/src/pages/PixelOffice.tsx` — 接入 useGamification
+
+## 依赖
+
+- WebSocket 推送 `agent-update` 事件（已有）
+- WebSocket 推送 `github:refresh` 事件（已有）
+- PixiApp 暴露 `highlightAgent(id)` 方法（待加）

--- a/packages/web/src/components/Leaderboard.tsx
+++ b/packages/web/src/components/Leaderboard.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import type { LeaderboardEntry } from '../hooks/useGamification';
+
+interface LeaderboardProps {
+  entries: LeaderboardEntry[];
+  onAgentClick?: (agentId: string) => void;
+}
+
+const MEDAL_COLORS = ['#ffd700', '#c0c0c0', '#cd7f32'];
+const STATUS_COLORS: Record<string, string> = {
+  online: '#22c55e',
+  busy: '#f59e0b',
+  away: '#94a3b8',
+  offline: '#64748b',
+  error: '#ef4444',
+};
+
+export function Leaderboard({ entries, onAgentClick }: LeaderboardProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="leaderboard" style={{
+      background: 'var(--glass-bg)',
+      border: '1px solid var(--glass-border)',
+      borderRadius: '8px',
+      overflow: 'hidden',
+    }}>
+      <div
+        onClick={() => setCollapsed(!collapsed)}
+        style={{
+          padding: '12px 16px',
+          cursor: 'pointer',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          borderBottom: collapsed ? 'none' : '1px solid var(--glass-border)',
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: '14px' }}>🏆 积分榜</span>
+        <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+          {collapsed ? '▶' : '▼'}
+        </span>
+      </div>
+
+      {!collapsed && (
+        <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+          {entries.slice(0, 10).map((entry) => (
+            <div
+              key={entry.agentId}
+              onClick={() => onAgentClick?.(entry.agentId)}
+              style={{
+                padding: '8px 16px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+                cursor: onAgentClick ? 'pointer' : 'default',
+                borderBottom: '1px solid var(--glass-border)',
+              }}
+            >
+              {/* Rank */}
+              <span style={{
+                width: '24px',
+                fontWeight: 700,
+                fontSize: '14px',
+                color: entry.rank <= 3 ? MEDAL_COLORS[entry.rank - 1] : 'var(--text-secondary)',
+                textAlign: 'center',
+              }}>
+                {entry.rank <= 3 ? ['🥇', '🥈', '🥉'][entry.rank - 1] : `#${entry.rank}`}
+              </span>
+
+              {/* Agent name */}
+              <span style={{
+                flex: 1,
+                fontSize: '13px',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}>
+                {entry.agentName}
+              </span>
+
+              {/* Status dot */}
+              <span style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
+                background: STATUS_COLORS[entry.status] ?? '#64748b',
+              }} />
+
+              {/* Score */}
+              <span style={{
+                fontSize: '14px',
+                fontWeight: 700,
+                minWidth: '50px',
+                textAlign: 'right',
+                fontFamily: 'monospace',
+              }}>
+                {Math.round(entry.score)}
+              </span>
+            </div>
+          ))}
+
+          {entries.length === 0 && (
+            <div style={{
+              padding: '24px',
+              textAlign: 'center',
+              color: 'var(--text-secondary)',
+              fontSize: '13px',
+            }}>
+              暂无数据
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/hooks/useGamification.ts
+++ b/packages/web/src/hooks/useGamification.ts
@@ -1,0 +1,145 @@
+import { useState, useCallback, useRef } from 'react';
+import type { Agent, AgentStatus, GitHubSummary } from '../types';
+
+interface AgentScore {
+  agentId: string;
+  agentName: string;
+  score: number;
+  busyMinutes: number;
+  onlineMinutes: number;
+  errorMinutes: number;
+  issuesResolved: number;
+  lastUpdated: number;
+}
+
+export interface LeaderboardEntry extends AgentScore {
+  rank: number;
+  status: AgentStatus;
+}
+
+interface UseGamificationOptions {
+  /** Called when leaderboard data changes */
+  onUpdate?: (leaderboard: LeaderboardEntry[]) => void;
+}
+
+const SCORE_WEIGHTS: Record<AgentStatus, number> = {
+  busy: 2,
+  online: 1,
+  away: 0,
+  offline: 0,
+  error: -1,
+};
+
+const ISSUE_POINTS = 5;
+
+export function useGamification(options: UseGamificationOptions = {}) {
+  const { onUpdate } = options;
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const scoresRef = useRef<Map<string, AgentScore>>(new Map());
+  const lastSeenIssuesRef = useRef<Map<string, number>>(new Map());
+  const lastTickRef = useRef<number>(Date.now());
+
+  /** Accumulate points based on elapsed time and current agent states */
+  const tick = useCallback((agents: Agent[]) => {
+    const now = Date.now();
+    const elapsedMs = now - lastTickRef.current;
+    const elapsedMinutes = elapsedMs / 60000;
+    lastTickRef.current = now;
+
+    const scores = scoresRef.current;
+
+    agents.forEach((agent) => {
+      const existing = scores.get(agent.id) || {
+        agentId: agent.id,
+        agentName: agent.name,
+        score: 0,
+        busyMinutes: 0,
+        onlineMinutes: 0,
+        errorMinutes: 0,
+        issuesResolved: 0,
+        lastUpdated: now,
+      };
+
+      const weight = SCORE_WEIGHTS[agent.status] || 0;
+      const earnedPoints = weight * elapsedMinutes;
+      const earnedMinutes = elapsedMinutes;
+
+      if (agent.status === 'busy') existing.busyMinutes += earnedMinutes;
+      if (agent.status === 'online') existing.onlineMinutes += earnedMinutes;
+      if (agent.status === 'error') existing.errorMinutes += earnedMinutes;
+
+      existing.score += earnedPoints;
+      existing.lastUpdated = now;
+      scores.set(agent.id, existing);
+    });
+
+    // Sort by score descending
+    const sorted = [...scores.values()]
+      .sort((a, b) => b.score - a.score)
+      .map((s, i): LeaderboardEntry => {
+        const agent = agents.find((ag) => ag.id === s.agentId);
+        return {
+          ...s,
+          rank: i + 1,
+          status: agent?.status ?? 'offline',
+        };
+      });
+
+    setLeaderboard(sorted);
+    onUpdate?.(sorted);
+  }, [onUpdate]);
+
+  /** Award bonus points for resolving an issue */
+  const awardIssuePoints = useCallback((agentId: string) => {
+    const score = scoresRef.current.get(agentId);
+    if (score) {
+      score.score += ISSUE_POINTS;
+      score.issuesResolved += 1;
+    }
+  }, []);
+
+  /** Handle GitHub refresh - award points for resolved issues */
+  const handleGitHubRefresh = useCallback((summary: GitHubSummary, prevSummary?: GitHubSummary) => {
+    if (!prevSummary) {
+      // First load - seed last seen counts
+      Object.entries(summary.byAssignee ?? {}).forEach(([assignee, count]) => {
+        lastSeenIssuesRef.current.set(assignee, count);
+      });
+      return summary;
+    }
+
+    Object.entries(summary.byAssignee ?? {}).forEach(([assignee, count]) => {
+      const lastSeen = lastSeenIssuesRef.current.get(assignee) ?? 0;
+      if (count > lastSeen) {
+        // Agent closed issues
+        const delta = count - lastSeen;
+        for (let i = 0; i < delta; i++) {
+          awardIssuePoints(assignee);
+        }
+        lastSeenIssuesRef.current.set(assignee, count);
+      }
+    });
+
+    return summary;
+  }, [awardIssuePoints]);
+
+  /** Reset all scores */
+  const reset = useCallback(() => {
+    scoresRef.current.clear();
+    lastTickRef.current = Date.now();
+    setLeaderboard([]);
+  }, []);
+
+  /** Get score for a specific agent */
+  const getScore = useCallback((agentId: string): AgentScore | undefined => {
+    return scoresRef.current.get(agentId);
+  }, []);
+
+  return {
+    leaderboard,
+    tick,
+    handleGitHubRefresh,
+    reset,
+    getScore,
+  };
+}

--- a/packages/web/src/styles/components.css
+++ b/packages/web/src/styles/components.css
@@ -892,3 +892,8 @@
   font-size: 12px;
   color: var(--text-muted);
 }
+
+/* ====== Leaderboard ====== */
+.leaderboard {
+  font-family: var(--font-sans);
+}


### PR DESCRIPTION
#57 Phase 1 - 游戏化基础

**新增：**
-  hook - 积分计算逻辑
-  组件 - 像素风格排行榜 UI

**积分规则：**
- busy → +2/min
- online → +1/min
- error → -1/min
- 每关闭1个issue → +5分

**待接入：**
- PixelOffice 接入 tick() 在 agent-update 时触发积分更新
- WebSocket github:refresh 触发 issue 奖励

**Build: ✅